### PR TITLE
Retry on team read and team parent_id read

### DIFF
--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -263,7 +263,7 @@ func resourceGithubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if parentTeamIdString, ok := d.GetOk("parent_team_id"); ok {
 		/*
-			Slug-name spefici (as opposed to using team ID):
+			Slug-name specific (as opposed to using team ID):
 			When updating nested teams via Terraform by looping through a module or resource
 			the parent team might not have been updated by a new slug-name yet
 			(in "terraform apply" parallel runs), so we are giving it some time to create the parent

--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -181,7 +181,7 @@ func resourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	/*
-		Slug-name spefici (as opposed to using team ID):
+		Slug-name specific (as opposed to using team ID):
 		When using slug-name to read GitHub teams it could be that another parallel thread of TF
 		(when looping through a module or resource) still needs to apply changes (rename the team name)
 		and thus it could be that we don't find it right away.


### PR DESCRIPTION
# Release 4.19.1

## Description

When changing a team name which has childs (and also changing the parent name accordingly in the childs) and applying it to all of it at the same time, then we 99% about team not found.

This is due to the fact that the parent name can be updated in the child teams first. Then they will try to validate the parent by url and name and this does not exist yet and will fail.

To mitigate this issue, I have implemented a loop with retries for that. During the retry time (meanwhile) the parent team will already have updated and the child team calls will succeed. 

## Goal

Have a stable TF GitHub provider which is not re-creating resources that don't have to.


## Why using our own provider?

I have tried three different module approaches for managing GitHub teams. All of them had issues and would have caused team re-creation for various cases, e.g.:
* team rename
* team moving up/down level

Additionally there is also a bug with the current provider when deleting teams: As TF runs in parallel and one of its threads deleted a parent team, the other threads were not able to schedule the child team for deletion (as GitHub automatically deleted child teams, when its parent team is removed). This resulted in TF errors.


## Importance of no re-creation

When teams get re-created (even by the same name):
1. all of its child teams also need to be recreated
2. All member assignments will be lost
3. All repository assignments will be lost

With the sheer amount of teams we have, we cannot afford to loose all these assignments. So the goal is to make it bullet-proof that no resources get re-created for all possible test-cases (see below).



## Currently tested / Features:

The following tests were done with multiple teams and child teams by using a list as input and for-looping over a module.
Terraform module code can be found here: https://github.com/integrations/terraform-provider-github/pull/802#issuecomment-1007382275

1. `terraform apply` from scratch
2. `terraform destroy`
3. `terraform apply` with a stand-alone team renamed
4. `terraform apply` with a parent team renamed team renamed
5. `terraform apply` with moving a stand-alone team one level up
6. `terraform apply` with moving a team (which contains childs) one level up



## Automation tests

With the hope that those changes make it to upstream, I will implement GitHub Integration tests on the TF module side (once it is available on GH), instead of the provider (as the upstream provider does have its own CI tests).
Tests were currently done in: https://github.com/orgs/cytopia-terraform-test. I will go ahead and create an official testing account for flaconi and switch over for the module itself.



## Downsides

The currently intended module design (for-loop module or for-loop resource) will not work with `terraform apply -parallelism=1`. It will work when using team ID's, but not when using team slug. However, when using a for-loop approach we cannot gather the ID's as this would result in circular dependencies and TF won't apply it.



## Note on tagging

I will tag it with 4.19.1 (it is then out-of-sync with upstream, but we already have ourselves the 4.19.0 version with assets attached)

## Informed upstream

Informed the author in upstream with clears steps on how to reproduce: https://github.com/integrations/terraform-provider-github/pull/802#issuecomment-1007382275